### PR TITLE
WIP: Update README with docker run cmd for x server

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ and run a command similar to:
 docker run -e DISPLAY=10.103.56.101:0 lvgl_simulator
 ```
 
+For an environment with X server, the following will the `docker run` command. Note that the first command, `xhost +` grants access to X server to everyone.
+
+```
+xhost +
+docker run -e DISPLAY=$DISPLAY -v /tmp/.X11-unix/:/tmp/.X11-unix:ro -t lvgl_simulator
+```
+
 ## Contributing
 1. Fork it!
 2. Create your feature branch: `git checkout -b my-new-feature`


### PR DESCRIPTION
The env vars and the xhost modification had to be done for an ubuntu
environment. Otherwise the simulator display would not start and an
error message would be visible.

The error message that would be visible if these steps are not done are,

```bash
$ docker run lvgl_simulator          
error: XDG_RUNTIME_DIR not set in the environment.                                         
error: XDG_RUNTIME_DIR not set in the environment.  
```